### PR TITLE
Add CDI tests using weld.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
       <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
+    <!-- Use Weld as a CDI container for CDI testing. -->
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-junit5</artifactId>
+      <version>4.0.3.Final</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/src/test/java/CDIManagedClientsTest.java
+++ b/src/test/java/CDIManagedClientsTest.java
@@ -1,0 +1,54 @@
+import api.check.v1.CheckRequest;
+import api.relations.v1.ReadRelationshipsRequest;
+import client.CheckClient;
+import client.Config;
+import client.RelationTuplesClient;
+import jakarta.inject.Inject;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Use Weld as a test container to check CDI functionality.
+ */
+@EnableWeld
+public class CDIManagedClientsTest {
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(new Weld().setBeanDiscoveryMode(BeanDiscoveryMode.ALL).addBeanClass(TestConfig.class)).build();
+
+    @Inject
+    CheckClient checkClient;
+
+    @Inject
+    RelationTuplesClient relationTuplesClient;
+
+    @Test
+    public void basicCDIWiringTestCheckClient() {
+        Assertions.assertThrows(io.grpc.StatusRuntimeException.class, () -> {
+            checkClient.check(CheckRequest.getDefaultInstance());
+        });
+    }
+
+    @Test
+    public void basicCDIWiringTestReadRelationships() {
+        Assertions.assertThrows(io.grpc.StatusRuntimeException.class, () -> {
+            relationTuplesClient.readRelationships(ReadRelationshipsRequest.getDefaultInstance());
+        });
+    }
+
+    static class TestConfig implements Config {
+        @Override
+        public boolean isSecureClients() {
+            return false;
+        }
+
+        @Override
+        public String targetUrl() {
+            return "240.0.0.0:8080"; // does not exist
+        }
+    }
+}


### PR DESCRIPTION
It's not always clear when CDI wiring/config is broken, so it seems risky not to have any tests involving bean wiring. This PR adds boilerplate and simple tests to test CDI functionality using Weld.