### PR TITLE
Change bean producers to @ApplicationScoped to satisfy quarkus mocks.

### DIFF
--- a/src/main/java/client/CDIManagedClients.java
+++ b/src/main/java/client/CDIManagedClients.java
@@ -14,6 +14,7 @@ import jakarta.enterprise.inject.Produces;
 @ApplicationScoped
 public class CDIManagedClients {
     @Produces
+    @ApplicationScoped
     RelationsGrpcClientsManager getManager(Config config) {
         var isSecureClients = config.isSecureClients();
         var targetUrl = config.targetUrl();
@@ -30,11 +31,13 @@ public class CDIManagedClients {
     }
 
     @Produces
+    @ApplicationScoped
     CheckClient getCheckClient(RelationsGrpcClientsManager manager) {
         return manager.getCheckClient();
     }
 
     @Produces
+    @ApplicationScoped
     RelationTuplesClient getRelationsClient(RelationsGrpcClientsManager manager) {
         return manager.getRelationTuplesClient();
     }


### PR DESCRIPTION
Quarkus @InjectMocks requires that only normal CDI-scoped beans be used. @Dependent scope is not supported. Changing clients and manager to @ApplicationScoped to make life easier for Quarkus folks (even though this seems to be an unfortunate quarkus-only requirement).