### PR TITLE
Add support for lookup subjects

### DIFF
--- a/src/main/java/org/project_kessel/relations/client/CDIManagedClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedClients.java
@@ -38,4 +38,9 @@ public class CDIManagedClients {
     RelationTuplesClient getRelationsClient(RelationsGrpcClientsManager manager) {
         return manager.getRelationTuplesClient();
     }
+
+    @Produces
+    LookupClient getLookupClient(RelationsGrpcClientsManager manager) {
+        return manager.getLookupClient();
+    }
 }

--- a/src/main/java/org/project_kessel/relations/client/LookupClient.java
+++ b/src/main/java/org/project_kessel/relations/client/LookupClient.java
@@ -1,0 +1,58 @@
+package org.project_kessel.relations.client;
+
+import io.grpc.Channel;
+import io.grpc.stub.StreamObserver;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+import org.project_kessel.api.relations.v0.KesselLookupServiceGrpc;
+import org.project_kessel.api.relations.v0.LookupSubjectsRequest;
+import org.project_kessel.api.relations.v0.LookupSubjectsResponse;
+
+import java.util.Iterator;
+import java.util.logging.Logger;
+
+public class LookupClient {
+    private static final Logger logger = Logger.getLogger(LookupClient.class.getName());
+
+    private final KesselLookupServiceGrpc.KesselLookupServiceStub asyncStub;
+    private final KesselLookupServiceGrpc.KesselLookupServiceBlockingStub blockingStub;
+
+    LookupClient(Channel channel) {
+        asyncStub = KesselLookupServiceGrpc.newStub(channel);
+        blockingStub = KesselLookupServiceGrpc.newBlockingStub(channel);
+    }
+
+    public void lookupSubjects(LookupSubjectsRequest request, StreamObserver<LookupSubjectsResponse> responseObserver) {
+        asyncStub.lookupSubjects(request, responseObserver);
+    }
+
+    public Iterator<LookupSubjectsResponse> lookupSubjects(LookupSubjectsRequest request) {
+        return blockingStub.lookupSubjects(request);
+    }
+
+    public Multi<LookupSubjectsResponse> lookupSubjectsMulti(LookupSubjectsRequest request) {
+        final UnicastProcessor<LookupSubjectsResponse> responseProcessor = UnicastProcessor.create();
+
+        var streamObserver = new StreamObserver<LookupSubjectsResponse>() {
+            @Override
+            public void onNext(LookupSubjectsResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+
+        var multi = Multi.createFrom().publisher(responseProcessor);
+        lookupSubjects(request, streamObserver);
+
+        return multi;
+    }
+}

--- a/src/main/java/org/project_kessel/relations/client/RelationsGrpcClientsManager.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationsGrpcClientsManager.java
@@ -82,4 +82,8 @@ public class RelationsGrpcClientsManager {
         return new RelationTuplesClient(channel);
     }
 
+    public LookupClient getLookupClient() {
+        return new LookupClient(channel);
+    }
+
 }

--- a/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
@@ -1,6 +1,7 @@
 package org.project_kessel.relations.client;
 
 import org.project_kessel.api.relations.v0.KesselCheckServiceGrpc;
+import org.project_kessel.api.relations.v0.KesselLookupServiceGrpc;
 import org.project_kessel.api.relations.v0.KesselTupleServiceGrpc;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,8 +55,6 @@ public class RelationsGrpcClientsManagerTest {
     public void testThreadingChaos() {
         /* Basic testing to ensure that we don't get ConcurrentModificationExceptions, or any other exceptions, when
          * creating and destroying managers on different threads. */
-
-
 
         try {
             Hashtable<String,RelationsGrpcClientsManager> managers = new Hashtable<>();
@@ -141,6 +140,7 @@ public class RelationsGrpcClientsManagerTest {
         var manager = RelationsGrpcClientsManager.forInsecureClients("localhost:8080");
         var checkClient = manager.getCheckClient();
         var relationTuplesClient = manager.getRelationTuplesClient();
+        var lookupClient = manager.getLookupClient();
 
         var checkAsyncStubField = CheckClient.class.getDeclaredField("asyncStub");
         checkAsyncStubField.setAccessible(true);
@@ -148,8 +148,12 @@ public class RelationsGrpcClientsManagerTest {
         var relationTuplesAsyncStubField = RelationTuplesClient.class.getDeclaredField("asyncStub");
         relationTuplesAsyncStubField.setAccessible(true);
         var relationTuplesChannel = ((KesselTupleServiceGrpc.KesselTupleServiceStub)relationTuplesAsyncStubField.get(relationTuplesClient)).getChannel();
+        var lookupAsyncStubField = LookupClient.class.getDeclaredField("asyncStub");
+        lookupAsyncStubField.setAccessible(true);
+        var lookupChannel = ((KesselLookupServiceGrpc.KesselLookupServiceStub)lookupAsyncStubField.get(lookupClient)).getChannel();
 
         assertEquals(checkChannel, relationTuplesChannel);
+        assertEquals(lookupChannel, relationTuplesChannel);
     }
 
     @Test


### PR DESCRIPTION
Add LookupClient with lookup subjects calls and tests.

This PR wraps the (existing) autogenerated stub code with client code as with the other services.