### PR TITLE
Remove disposes method that might break a client in another scope.

### DIFF
--- a/src/main/java/org/project_kessel/relations/client/CDIManagedClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedClients.java
@@ -1,12 +1,10 @@
 package org.project_kessel.relations.client;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 
 /**
  * A managed bean for providing relations api clients for injection in apps.
- * Performs some lifecycle management.
  * It has the current limitation that only one underlying grpc connection can be configured.
  * However, it is still possible to create more via RelationsGrpcClientsManager directly.
  * This class does nothing unless the client is being managed by a CDI container (e.g. Quarkus)
@@ -23,10 +21,6 @@ public class CDIManagedClients {
         }
 
         return RelationsGrpcClientsManager.forInsecureClients(targetUrl);
-    }
-
-    void shutdownClientsManager(@Disposes RelationsGrpcClientsManager manager) {
-        RelationsGrpcClientsManager.shutdownManager(manager);
     }
 
     @Produces


### PR DESCRIPTION
The problem with this @Disposes method is that in a non-ApplicationScoped scope, like @RequestScoped, the removal of client and RelationsGrpcClientsManager beans (at the end of a request) could lead to the closing of a channel in an underlying RelationsGrpcClientsManager that is shared by another bean.