### PR TITLE
RHCLOUD-33423: Add updated protos and support for proto validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>grpc-stub</artifactId>
       <version>1.64.0</version>
     </dependency>
+    <dependency>
+      <groupId>build.buf.protoc-gen-validate</groupId>
+      <artifactId>pgv-java-stub</artifactId>
+      <version>1.0.4</version>
+    </dependency>
     <dependency> <!-- necessary for Java 9+ -->
       <groupId>org.apache.tomcat</groupId>
       <artifactId>annotations-api</artifactId>
@@ -127,6 +132,19 @@
               <goal>compile</goal>
               <goal>compile-custom</goal>
             </goals>
+          </execution>
+          <execution>
+            <id>protoc-java-pgv</id>
+            <goals>
+              <goal>compile-custom</goal>
+            </goals>
+            <configuration>
+              <pluginParameter>lang=java</pluginParameter>
+              <pluginId>java-pgv</pluginId>
+              <pluginArtifact>
+                build.buf.protoc-gen-validate:protoc-gen-validate:1.0.4:exe:${os.detected.classifier}
+              </pluginArtifact>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/proto/relations/v0/check.proto
+++ b/src/main/proto/relations/v0/check.proto
@@ -4,6 +4,8 @@ package kessel.relations.v0;
 
 import "google/api/annotations.proto";
 import "relations/v0/common.proto";
+import "validate/validate.proto";
+
 
 option go_package = "github.com/project-kessel/relations-api/api/relations/v0";
 option java_multiple_files = true;
@@ -21,9 +23,9 @@ service KesselCheckService {
 }
 
 message CheckRequest {
-	ObjectReference resource = 1;
-	string relation = 2;
-	SubjectReference subject = 3;
+	ObjectReference resource = 1 [(validate.rules).any.required = true];
+	string relation = 2 [(validate.rules).string.min_len = 1];
+	SubjectReference subject = 3 [(validate.rules).any.required = true];
 }
 
 message CheckResponse {

--- a/src/main/proto/relations/v0/common.proto
+++ b/src/main/proto/relations/v0/common.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package kessel.relations.v0;
 
+import "validate/validate.proto";
+
 option go_package = "github.com/project-kessel/relations-api/api/relations/v0";
 option java_multiple_files = true;
 option java_package = "org.project_kessel.api.relations.v0";
@@ -16,9 +18,9 @@ option java_package = "org.project_kessel.api.relations.v0";
 // Conventionally, we generally refer to the Resource first, then Subject,
 // following the direction of typical graph traversal (Resource to Subject).
 message Relationship {
-	ObjectReference resource = 1;
-	string relation = 2;
-	SubjectReference subject = 3;
+	ObjectReference resource = 1 [(validate.rules).any.required = true]; 
+	string relation = 2 [(validate.rules).string.min_len = 1];
+	SubjectReference subject = 3 [(validate.rules).any.required = true];
 }
 
 // A reference to a Subject or, if a `relation` is provided, a Subject Set.
@@ -26,11 +28,11 @@ message SubjectReference {
 	// An optional relation which points to a set of Subjects instead of the single Subject.
 	// e.g. "members" or "owners" of a group identified in `subject`.
 	optional string relation = 1;
-	ObjectReference subject = 2;
+	ObjectReference subject = 2 [(validate.rules).any.required = true];
 }
 
 message RequestPagination {
-	uint32 limit = 1;
+	uint32 limit = 1 [(validate.rules).uint32 = {gt: 0}];
 	optional string continuation_token = 2;
 }
 
@@ -39,11 +41,11 @@ message ResponsePagination {
 }
 
 message ObjectReference {
-	ObjectType type = 1;
-	string id = 2;
+	ObjectType type = 1 [(validate.rules).any.required = true];
+	string id = 2 [(validate.rules).string.min_len = 1];
 }
 
 message ObjectType {
-	string namespace = 1;
-	string name = 2;
+	string namespace = 1 [(validate.rules).string.min_len = 1];
+	string name = 2 [(validate.rules).string.min_len = 1];
 }

--- a/src/main/proto/relations/v0/lookup.proto
+++ b/src/main/proto/relations/v0/lookup.proto
@@ -4,6 +4,8 @@ package kessel.relations.v0;
 
 import "google/api/annotations.proto";
 import "relations/v0/common.proto";
+import "validate/validate.proto";
+
 
 option go_package = "github.com/project-kessel/relations-api/api/relations/v0";
 option java_multiple_files = true;
@@ -18,9 +20,9 @@ service KesselLookupService {
 }
 
 message LookupSubjectsRequest {
-    ObjectReference resource = 1;
-    string relation = 2;
-    ObjectType subject_type = 3;
+    ObjectReference resource = 1 [(validate.rules).any.required = true];
+    string relation = 2 [(validate.rules).string.min_len = 1];
+    ObjectType subject_type = 3 [(validate.rules).any.required = true];
     optional string subject_relation = 4;
     optional RequestPagination pagination = 5;
 }

--- a/src/main/proto/relations/v0/relation_tuples.proto
+++ b/src/main/proto/relations/v0/relation_tuples.proto
@@ -4,6 +4,7 @@ package kessel.relations.v0;
 
 import "google/api/annotations.proto";
 import "relations/v0/common.proto";
+import "validate/validate.proto";
 
 option go_package = "github.com/project-kessel/relations-api/api/relations/v0";
 option java_multiple_files = true;
@@ -46,7 +47,7 @@ message CreateTuplesRequest {
 message CreateTuplesResponse {}
 
 message ReadTuplesRequest {
-	RelationTupleFilter filter = 1;
+	RelationTupleFilter filter = 1 [(validate.rules).any.required = true];
 	optional RequestPagination pagination = 2;
 }
 message ReadTuplesResponse {
@@ -55,7 +56,7 @@ message ReadTuplesResponse {
 }
 
 message DeleteTuplesRequest {
-	RelationTupleFilter filter = 1;
+	RelationTupleFilter filter = 1 [(validate.rules).any.required = true];
 }
 message DeleteTuplesResponse {}
 


### PR DESCRIPTION
Done:
- Add updated proto files with validation rules.
- Add protobuf validation dependency and plugins to parse validation rules and to generate validators.

Not done:
- Client side request validation using the generated validators.

Notes:
- New dependency added: build.buf.protoc-gen-validate. This is needed for 2 reasons: 1) to parse protos with validation rules (without an error) and 2) to generate validators. If we were never going to do 2, we could ensure that the dependency was excluded from the built jar (but with 2, the dependencies are needed).