### PR TITLE
RHCLOUD 33050 - GitHub actions pipeline w/ Linting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,5 +25,5 @@ jobs:
         java-version: '21'
         distribution: 'zulu'
         cache: maven
-    - name: Build and test with Maven
-      run: ./mvnw -B package --file pom.xml
+    - name: Build, test, and run linter with Maven
+      run: ./mvnw -B package --file pom.xml # package runs validate, compile, test & package

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -135,7 +135,6 @@
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
-    <module name="MissingSwitchDefault"/>
     <module name="FallThrough"/>
     <module name="UpperEll"/>
     <module name="ModifierOrder"/>
@@ -253,7 +252,7 @@
     <module name="Indentation">
       <property name="basicOffset" value="4"/>
       <property name="braceAdjustment" value="2"/>
-      <property name="caseIndent" value="2"/>
+      <property name="caseIndent" value="4"/>
       <property name="throwsIndent" value="4"/>
       <property name="lineWrappingIndentation" value="8"/>
       <property name="arrayInitIndent" value="2"/>

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -267,7 +267,6 @@
     </module> -->
     <module name="NoWhitespaceBeforeCaseDefaultColon"/>
     <module name="OverloadMethodsDeclarationOrder"/>
-    <module name="VariableDeclarationUsageDistance"/>
     <module name="CustomImportOrder">
       <property name="sortImportsInGroupAlphabetically" value="false"/>
       <property name="separateLineBetweenGroups" value="true"/>

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -1,0 +1,382 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+  <module name="SuppressWarningsFilter"/>
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+               value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="tokens"
+               value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <!-- <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module> -->
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="8"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+    <!-- <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module> -->
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="false"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <!-- <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module> -->
+    <!-- <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module> -->
+    <!-- <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module> -->
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9]\w*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SingleLineJavadoc"/>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
           <configLocation>google_checks.xml</configLocation>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
+          <violationSeverity>warning</violationSeverity>
           <linkXRef>false</linkXRef>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
           <failsOnError>true</failsOnError>
           <violationSeverity>warning</violationSeverity>
           <linkXRef>false</linkXRef>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,33 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.4.0</version>
+        <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>10.17.0</version>
+            </dependency>
+          </dependencies>
+        <configuration>
+          <configLocation>google_checks.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <linkXRef>false</linkXRef>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>net.nicoulaj.maven.plugins</groupId>
         <artifactId>checksum-maven-plugin</artifactId>
         <version>1.10</version>

--- a/src/main/java/org/project_kessel/relations/client/AuthnConfigConverter.java
+++ b/src/main/java/org/project_kessel/relations/client/AuthnConfigConverter.java
@@ -7,12 +7,13 @@ import org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsAuthent
 public class AuthnConfigConverter {
 
     public static AuthenticationConfig convert(Config.AuthenticationConfig authnConfig) {
-        if(authnConfig == null) {
+        if (authnConfig == null) {
             return null;
         }
         AuthenticationConfig convertedAuthnConfig;
-        if(authnConfig.clientCredentialsConfig().isPresent()) {
-            Config.OIDCClientCredentialsConfig oidcClientCredentialsConfig = authnConfig.clientCredentialsConfig().get();
+        if (authnConfig.clientCredentialsConfig().isPresent()) {
+            Config.OIDCClientCredentialsConfig oidcClientCredentialsConfig =
+                    authnConfig.clientCredentialsConfig().get();
 
             convertedAuthnConfig = new OIDCClientCredentialsAuthenticationConfig();
             var convertedOidcClientCredentialsConfig = new OIDCClientCredentialsConfig();
@@ -20,9 +21,11 @@ public class AuthnConfigConverter {
             convertedOidcClientCredentialsConfig.setClientId(oidcClientCredentialsConfig.clientId());
             convertedOidcClientCredentialsConfig.setClientSecret(oidcClientCredentialsConfig.clientSecret());
             convertedOidcClientCredentialsConfig.setScope(oidcClientCredentialsConfig.scope());
-            convertedOidcClientCredentialsConfig.setOidcClientCredentialsMinterImplementation(oidcClientCredentialsConfig.oidcClientCredentialsMinterImplementation());
+            convertedOidcClientCredentialsConfig.setOidcClientCredentialsMinterImplementation(
+                    oidcClientCredentialsConfig.oidcClientCredentialsMinterImplementation());
 
-            ((OIDCClientCredentialsAuthenticationConfig)convertedAuthnConfig).setCredentialsConfig(convertedOidcClientCredentialsConfig);
+            ((OIDCClientCredentialsAuthenticationConfig) convertedAuthnConfig).setCredentialsConfig(
+                    convertedOidcClientCredentialsConfig);
         } else {
             convertedAuthnConfig = new AuthenticationConfig();
         }

--- a/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
@@ -19,13 +19,13 @@ public class CDIManagedRelationsClients {
         var authnEnabled = config.authenticationConfig().map(t -> !t.mode().equals(AuthMode.DISABLED)).orElse(false);
 
         if (isSecureClients) {
-            if(authnEnabled) {
+            if (authnEnabled) {
                 return RelationsGrpcClientsManager.forSecureClients(targetUrl, config.authenticationConfig().get());
             }
             return RelationsGrpcClientsManager.forSecureClients(targetUrl);
         }
 
-        if(authnEnabled) {
+        if (authnEnabled) {
             return RelationsGrpcClientsManager.forInsecureClients(targetUrl, config.authenticationConfig().get());
         }
         return RelationsGrpcClientsManager.forInsecureClients(targetUrl);

--- a/src/main/java/org/project_kessel/relations/client/CheckClient.java
+++ b/src/main/java/org/project_kessel/relations/client/CheckClient.java
@@ -1,17 +1,17 @@
 package org.project_kessel.relations.client;
 
-import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.CheckRequest;
-import org.project_kessel.api.relations.v1beta1.CheckResponse;
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+import java.util.logging.Logger;
+import org.project_kessel.api.relations.v1beta1.CheckRequest;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
 import org.project_kessel.clients.KesselClient;
 
-import java.util.logging.Logger;
-
-public class CheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheckServiceStub, KesselCheckServiceGrpc.KesselCheckServiceBlockingStub> {
+public class CheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheckServiceStub,
+        KesselCheckServiceGrpc.KesselCheckServiceBlockingStub> {
     private static final Logger logger = Logger.getLogger(CheckClient.class.getName());
 
     CheckClient(Channel channel) {

--- a/src/main/java/org/project_kessel/relations/client/CheckClient.java
+++ b/src/main/java/org/project_kessel/relations/client/CheckClient.java
@@ -23,6 +23,10 @@ public class CheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheck
         asyncStub.check(request, responseObserver);
     }
 
+    public CheckResponse check(CheckRequest request) {
+        return blockingStub.check(request);
+    }
+
     public Uni<CheckResponse> checkUni(CheckRequest request) {
         final UnicastProcessor<CheckResponse> responseProcessor = UnicastProcessor.create();
 
@@ -47,9 +51,5 @@ public class CheckClient extends KesselClient<KesselCheckServiceGrpc.KesselCheck
         check(request, streamObserver);
 
         return uni;
-    }
-
-    public CheckResponse check(CheckRequest request) {
-        return blockingStub.check(request);
     }
 }

--- a/src/main/java/org/project_kessel/relations/client/Config.java
+++ b/src/main/java/org/project_kessel/relations/client/Config.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public interface Config {
     @WithDefault("false")
     boolean isSecureClients();
+    
     String targetUrl();
 
     @WithName("authn")

--- a/src/main/java/org/project_kessel/relations/client/Config.java
+++ b/src/main/java/org/project_kessel/relations/client/Config.java
@@ -26,17 +26,22 @@ public interface Config {
     interface AuthenticationConfig {
         @WithDefault("disabled")
         AuthMode mode();
+        
         @WithName("client")
         Optional<OIDCClientCredentialsConfig> clientCredentialsConfig();
     }
 
-     interface OIDCClientCredentialsConfig {
+    interface OIDCClientCredentialsConfig {
         String issuer();
+        
         @WithName("id")
         String clientId();
+        
         @WithName("secret")
         String clientSecret();
+        
         Optional<String[]> scope();
+
         Optional<String> oidcClientCredentialsMinterImplementation();
     }
 }

--- a/src/main/java/org/project_kessel/relations/client/Config.java
+++ b/src/main/java/org/project_kessel/relations/client/Config.java
@@ -3,9 +3,8 @@ package org.project_kessel.relations.client;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
-import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
-
 import java.util.Optional;
+import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
 
 /**
  * Interface for injecting config into container managed beans.
@@ -17,7 +16,7 @@ import java.util.Optional;
 public interface Config {
     @WithDefault("false")
     boolean isSecureClients();
-    
+
     String targetUrl();
 
     @WithName("authn")
@@ -26,20 +25,20 @@ public interface Config {
     interface AuthenticationConfig {
         @WithDefault("disabled")
         AuthMode mode();
-        
+
         @WithName("client")
         Optional<OIDCClientCredentialsConfig> clientCredentialsConfig();
     }
 
     interface OIDCClientCredentialsConfig {
         String issuer();
-        
+
         @WithName("id")
         String clientId();
-        
+
         @WithName("secret")
         String clientSecret();
-        
+
         Optional<String[]> scope();
 
         Optional<String> oidcClientCredentialsMinterImplementation();

--- a/src/main/java/org/project_kessel/relations/client/LookupClient.java
+++ b/src/main/java/org/project_kessel/relations/client/LookupClient.java
@@ -4,13 +4,17 @@ import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
-import org.project_kessel.api.relations.v1beta1.*;
-import org.project_kessel.clients.KesselClient;
-
 import java.util.Iterator;
 import java.util.logging.Logger;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsResponse;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsRequest;
+import org.project_kessel.api.relations.v1beta1.LookupResourcesResponse;
+import org.project_kessel.api.relations.v1beta1.LookupResourcesRequest;
+import org.project_kessel.api.relations.v1beta1.KesselLookupServiceGrpc;
+import org.project_kessel.clients.KesselClient;
 
-public class LookupClient extends KesselClient<KesselLookupServiceGrpc.KesselLookupServiceStub,KesselLookupServiceGrpc.KesselLookupServiceBlockingStub> {
+public class LookupClient extends KesselClient<KesselLookupServiceGrpc.KesselLookupServiceStub,
+        KesselLookupServiceGrpc.KesselLookupServiceBlockingStub> {
     private static final Logger logger = Logger.getLogger(LookupClient.class.getName());
 
     LookupClient(Channel channel) {
@@ -25,8 +29,8 @@ public class LookupClient extends KesselClient<KesselLookupServiceGrpc.KesselLoo
         return blockingStub.lookupSubjects(request);
     }
 
-    public void lookupResources(LookupResourcesRequest request, 
-            StreamObserver<LookupResourcesResponse> responseObserver) {
+    public void lookupResources(LookupResourcesRequest request,
+                                StreamObserver<LookupResourcesResponse> responseObserver) {
         asyncStub.lookupResources(request, responseObserver);
     }
 

--- a/src/main/java/org/project_kessel/relations/client/LookupClient.java
+++ b/src/main/java/org/project_kessel/relations/client/LookupClient.java
@@ -21,7 +21,12 @@ public class LookupClient extends KesselClient<KesselLookupServiceGrpc.KesselLoo
         asyncStub.lookupSubjects(request, responseObserver);
     }
 
-    public void lookupResources(LookupResourcesRequest request, StreamObserver<LookupResourcesResponse> responseObserver) {
+    public Iterator<LookupSubjectsResponse> lookupSubjects(LookupSubjectsRequest request) {
+        return blockingStub.lookupSubjects(request);
+    }
+
+    public void lookupResources(LookupResourcesRequest request, 
+            StreamObserver<LookupResourcesResponse> responseObserver) {
         asyncStub.lookupResources(request, responseObserver);
     }
 
@@ -53,10 +58,6 @@ public class LookupClient extends KesselClient<KesselLookupServiceGrpc.KesselLoo
         lookupResources(request, streamObserver);
 
         return multi;
-    }
-
-    public Iterator<LookupSubjectsResponse> lookupSubjects(LookupSubjectsRequest request) {
-        return blockingStub.lookupSubjects(request);
     }
 
     public Multi<LookupSubjectsResponse> lookupSubjectsMulti(LookupSubjectsRequest request) {

--- a/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
@@ -1,26 +1,27 @@
 package org.project_kessel.relations.client;
 
-import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.DeleteTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.DeleteTuplesResponse;
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
+import java.util.Iterator;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.DeleteTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.DeleteTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
 import org.project_kessel.clients.KesselClient;
 
-import java.util.Iterator;
-
-public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.KesselTupleServiceStub, KesselTupleServiceGrpc.KesselTupleServiceBlockingStub> {
+public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.KesselTupleServiceStub,
+        KesselTupleServiceGrpc.KesselTupleServiceBlockingStub> {
     RelationTuplesClient(Channel channel) {
         super(KesselTupleServiceGrpc.newStub(channel), KesselTupleServiceGrpc.newBlockingStub(channel));
     }
 
     /**
+     *
      */
     public void createTuples(CreateTuplesRequest request,
                              StreamObserver<CreateTuplesResponse> responseObserver) {
@@ -28,12 +29,14 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
     }
 
     /**
+     *
      */
     public CreateTuplesResponse createTuples(CreateTuplesRequest request) {
         return blockingStub.createTuples(request);
     }
 
     /**
+     *
      */
     public void readTuples(ReadTuplesRequest request,
                            StreamObserver<ReadTuplesResponse> responseObserver) {
@@ -41,12 +44,14 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
     }
 
     /**
+     *
      */
     public Iterator<ReadTuplesResponse> readTuples(ReadTuplesRequest request) {
         return blockingStub.readTuples(request);
     }
 
     /**
+     *
      */
     public void deleteTuples(DeleteTuplesRequest request,
                              StreamObserver<DeleteTuplesResponse> responseObserver) {
@@ -54,6 +59,7 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
     }
 
     /**
+     *
      */
     public DeleteTuplesResponse deleteTuples(DeleteTuplesRequest request) {
         return blockingStub.deleteTuples(request);

--- a/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
@@ -29,6 +29,12 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
 
     /**
      */
+    public CreateTuplesResponse createTuples(CreateTuplesRequest request) {
+        return blockingStub.createTuples(request);
+    }
+
+    /**
+     */
     public void readTuples(ReadTuplesRequest request,
                            StreamObserver<ReadTuplesResponse> responseObserver) {
         asyncStub.readTuples(request, responseObserver);
@@ -36,21 +42,15 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
 
     /**
      */
+    public Iterator<ReadTuplesResponse> readTuples(ReadTuplesRequest request) {
+        return blockingStub.readTuples(request);
+    }
+
+    /**
+     */
     public void deleteTuples(DeleteTuplesRequest request,
                              StreamObserver<DeleteTuplesResponse> responseObserver) {
         asyncStub.deleteTuples(request, responseObserver);
-    }
-
-    /**
-     */
-    public CreateTuplesResponse createTuples(CreateTuplesRequest request) {
-        return blockingStub.createTuples(request);
-    }
-
-    /**
-     */
-    public Iterator<ReadTuplesResponse> readTuples(ReadTuplesRequest request) {
-        return blockingStub.readTuples(request);
     }
 
     /**

--- a/src/main/java/org/project_kessel/relations/client/RelationsGrpcClientsManager.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationsGrpcClientsManager.java
@@ -5,26 +5,33 @@ import org.project_kessel.clients.ChannelManager;
 import org.project_kessel.clients.KesselClientsManager;
 
 public class RelationsGrpcClientsManager extends KesselClientsManager {
+    private static final String CHANNEL_MANAGER_KEY = RelationsGrpcClientsManager.class.getName();
+
     private RelationsGrpcClientsManager(Channel channel) {
         super(channel);
     }
 
-    private static final String CHANNEL_MANAGER_KEY = RelationsGrpcClientsManager.class.getName();
-
     public static RelationsGrpcClientsManager forInsecureClients(String targetUrl) {
-        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl));
+        return new RelationsGrpcClientsManager(
+                ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl));
     }
 
-    public static RelationsGrpcClientsManager forInsecureClients(String targetUrl, Config.AuthenticationConfig authnConfig) throws RuntimeException {
-        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forInsecureClients(targetUrl, AuthnConfigConverter.convert(authnConfig)));
+    public static RelationsGrpcClientsManager forInsecureClients(String targetUrl,
+                                                                 Config.AuthenticationConfig authnConfig)
+            throws RuntimeException {
+        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY)
+                .forInsecureClients(targetUrl, AuthnConfigConverter.convert(authnConfig)));
     }
 
     public static RelationsGrpcClientsManager forSecureClients(String targetUrl) {
-        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forSecureClients(targetUrl));
+        return new RelationsGrpcClientsManager(
+                ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forSecureClients(targetUrl));
     }
 
-    public static RelationsGrpcClientsManager forSecureClients(String targetUrl, Config.AuthenticationConfig authnConfig) {
-        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY).forSecureClients(targetUrl, AuthnConfigConverter.convert(authnConfig)));
+    public static RelationsGrpcClientsManager forSecureClients(String targetUrl,
+                                                               Config.AuthenticationConfig authnConfig) {
+        return new RelationsGrpcClientsManager(ChannelManager.getInstance(CHANNEL_MANAGER_KEY)
+                .forSecureClients(targetUrl, AuthnConfigConverter.convert(authnConfig)));
     }
 
     public static void shutdownAll() {

--- a/src/main/java/org/project_kessel/relations/example/Caller.java
+++ b/src/main/java/org/project_kessel/relations/example/Caller.java
@@ -1,17 +1,27 @@
 package org.project_kessel.relations.example;
 
-import org.project_kessel.api.relations.v1beta1.*;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.project_kessel.relations.client.RelationsGrpcClientsManager;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsResponse;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsRequest;
+import org.project_kessel.api.relations.v1beta1.LookupResourcesResponse;
+import org.project_kessel.api.relations.v1beta1.LookupResourcesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.RelationTupleFilter;
+import org.project_kessel.api.relations.v1beta1.CheckRequest;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.SubjectReference;
+import org.project_kessel.relations.client.RelationsGrpcClientsManager;
 
 public class Caller {
 
@@ -27,11 +37,11 @@ public class Caller {
 
         var checkRequest = CheckRequest.newBuilder()
                 .setSubject(SubjectReference.newBuilder()
-                                .setSubject(ObjectReference.newBuilder()
-                                        .setType(ObjectType.newBuilder()
-                                                .setName("user").build())
-                                        .setId(userName).build())
-                                .build())
+                        .setSubject(ObjectReference.newBuilder()
+                                .setType(ObjectType.newBuilder()
+                                        .setName("user").build())
+                                .setId(userName).build())
+                        .build())
                 .setRelation(permission)
                 .setResource(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
@@ -249,11 +259,11 @@ public class Caller {
         var lookupResourcesRequest = LookupResourcesRequest.newBuilder()
                 .setResourceType(ObjectType.newBuilder().setName("thing"))
                 .setRelation("view").setSubject(SubjectReference.newBuilder()
-                  .setSubject(ObjectReference.newBuilder()
-                        .setType(ObjectType.newBuilder()
-                                .setName("user").build())
-                        .setId("bob").build())
-                .build()).build();
+                        .setSubject(ObjectReference.newBuilder()
+                                .setType(ObjectType.newBuilder()
+                                        .setName("user").build())
+                                .setId("bob").build())
+                        .build()).build();
 
         var resourceIterator = lookupClient.lookupResources(lookupResourcesRequest);
         Iterable<LookupResourcesResponse> iterable = () -> resourceIterator;

--- a/src/main/java/org/project_kessel/relations/example/Caller.java
+++ b/src/main/java/org/project_kessel/relations/example/Caller.java
@@ -50,7 +50,7 @@ public class Caller {
         var checkResponse = checkClient.check(checkRequest);
         var permitted = checkResponse.getAllowed() == CheckResponse.Allowed.ALLOWED_TRUE;
 
-        if(permitted) {
+        if (permitted) {
             System.out.println("Blocking: Permitted");
         } else {
             System.out.println("Blocking: Denied");
@@ -69,7 +69,7 @@ public class Caller {
                  */
                 var permitted = response.getAllowed() == CheckResponse.Allowed.ALLOWED_TRUE;
 
-                if(permitted) {
+                if (permitted) {
                     System.out.println("Non-blocking: Permitted");
                 } else {
                     System.out.println("Non-blocking: Denied");
@@ -105,7 +105,7 @@ public class Caller {
         /* Pattern where we may want collect all the responses, but still operate on each as it comes in. */
         CheckResponse cr = uni.onItem()
                 .invoke(() -> {
-                    if(permitted) {
+                    if (permitted) {
                         System.out.println("Reactive non-blocking: Permitted");
                     } else {
                         System.out.println("Reactive non-blocking: Denied");
@@ -246,10 +246,10 @@ public class Caller {
         var clientsManager = RelationsGrpcClientsManager.forInsecureClients(url);
         var lookupClient = clientsManager.getLookupClient();
 
-        var lookupResourcesRequest = LookupResourcesRequest.newBuilder().
-                setResourceType(ObjectType.newBuilder().setName("thing"))
-              .setRelation("view").setSubject(SubjectReference.newBuilder()
-                .setSubject(ObjectReference.newBuilder()
+        var lookupResourcesRequest = LookupResourcesRequest.newBuilder()
+                .setResourceType(ObjectType.newBuilder().setName("thing"))
+                .setRelation("view").setSubject(SubjectReference.newBuilder()
+                  .setSubject(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
                                 .setName("user").build())
                         .setId("bob").build())

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
@@ -1,6 +1,20 @@
 package org.project_kessel.relations.client;
 
-import org.project_kessel.api.relations.v1beta1.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.KesselLookupServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.CheckRequest;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsRequest;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsResponse;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.Relationship;
+import org.project_kessel.api.relations.v1beta1.SubjectReference;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
@@ -13,11 +27,9 @@ import org.jboss.weld.junit5.WeldSetup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Use Weld as a test container to check CDI functionality.
@@ -25,7 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @EnableWeld
 class CDIManagedRelationsClientsContainerTests {
     @WeldSetup
-    public WeldInitiator weld = WeldInitiator.from(new Weld().setBeanDiscoveryMode(BeanDiscoveryMode.ALL).addBeanClass(TestConfig.class)).build();
+    public WeldInitiator weld = WeldInitiator.from(new Weld().setBeanDiscoveryMode(BeanDiscoveryMode.ALL)
+            .addBeanClass(TestConfig.class)).build();
 
     private static final int testServerPort = 7000;
 
@@ -50,7 +63,8 @@ class CDIManagedRelationsClientsContainerTests {
         serverBuilder.addService(new KesselCheckServiceGrpc.KesselCheckServiceImplBase() {
             @Override
             public void check(CheckRequest request, StreamObserver<CheckResponse> responseObserver) {
-                responseObserver.onNext(CheckResponse.newBuilder().setAllowed(CheckResponse.Allowed.ALLOWED_TRUE).build());
+                responseObserver.onNext(CheckResponse.newBuilder().setAllowed(CheckResponse.Allowed.ALLOWED_TRUE)
+                        .build());
                 responseObserver.onCompleted();
             }
         });
@@ -69,7 +83,8 @@ class CDIManagedRelationsClientsContainerTests {
         });
         serverBuilder.addService(new KesselLookupServiceGrpc.KesselLookupServiceImplBase() {
             @Override
-            public void lookupSubjects(LookupSubjectsRequest request, StreamObserver<LookupSubjectsResponse> responseObserver) {
+            public void lookupSubjects(LookupSubjectsRequest request, 
+                    StreamObserver<LookupSubjectsResponse> responseObserver) {
                 responseObserver.onNext(LookupSubjectsResponse.newBuilder().setSubject(
                         SubjectReference.newBuilder().setSubject(
                                 ObjectReference.newBuilder().setId("TestSubjectId")

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
@@ -1,24 +1,14 @@
 package org.project_kessel.relations.client;
 
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.KesselLookupServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.CheckRequest;
-import org.project_kessel.api.relations.v1beta1.CheckResponse;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.LookupSubjectsRequest;
-import org.project_kessel.api.relations.v1beta1.LookupSubjectsResponse;
-import org.project_kessel.api.relations.v1beta1.ObjectReference;
-import org.project_kessel.api.relations.v1beta1.ObjectType;
-import org.project_kessel.api.relations.v1beta1.Relationship;
-import org.project_kessel.api.relations.v1beta1.SubjectReference;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import jakarta.inject.Inject;
+import java.io.IOException;
+import java.util.Optional;
 import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.junit5.EnableWeld;
@@ -27,8 +17,19 @@ import org.jboss.weld.junit5.WeldSetup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import java.io.IOException;
-import java.util.Optional;
+import org.project_kessel.api.relations.v1beta1.CheckRequest;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.KesselLookupServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsRequest;
+import org.project_kessel.api.relations.v1beta1.LookupSubjectsResponse;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.Relationship;
+import org.project_kessel.api.relations.v1beta1.SubjectReference;
 
 
 /**
@@ -36,22 +37,17 @@ import java.util.Optional;
  */
 @EnableWeld
 class CDIManagedRelationsClientsContainerTests {
+    private static final int testServerPort = 7000;
+    private static Server grpcServer;
     @WeldSetup
     public WeldInitiator weld = WeldInitiator.from(new Weld().setBeanDiscoveryMode(BeanDiscoveryMode.ALL)
             .addBeanClass(TestConfig.class)).build();
-
-    private static final int testServerPort = 7000;
-
     @Inject
     CheckClient checkClient;
-
     @Inject
     RelationTuplesClient relationTuplesClient;
-
     @Inject
     LookupClient lookupClient;
-
-    private static Server grpcServer;
 
     /*
      Start a grpcServer with the following services added and some custom responses that we can check for in the tests.
@@ -72,24 +68,24 @@ class CDIManagedRelationsClientsContainerTests {
             @Override
             public void readTuples(ReadTuplesRequest request, StreamObserver<ReadTuplesResponse> responseObserver) {
                 responseObserver.onNext(ReadTuplesResponse.newBuilder().setTuple(
-                        Relationship.newBuilder().setResource(
-                                ObjectReference.newBuilder().setType(
-                                        ObjectType.newBuilder().setName("TestType"))
+                                Relationship.newBuilder().setResource(
+                                                ObjectReference.newBuilder().setType(
+                                                                ObjectType.newBuilder().setName("TestType"))
+                                                        .build())
                                         .build())
-                                .build())
                         .build());
                 responseObserver.onCompleted();
             }
         });
         serverBuilder.addService(new KesselLookupServiceGrpc.KesselLookupServiceImplBase() {
             @Override
-            public void lookupSubjects(LookupSubjectsRequest request, 
-                    StreamObserver<LookupSubjectsResponse> responseObserver) {
+            public void lookupSubjects(LookupSubjectsRequest request,
+                                       StreamObserver<LookupSubjectsResponse> responseObserver) {
                 responseObserver.onNext(LookupSubjectsResponse.newBuilder().setSubject(
-                        SubjectReference.newBuilder().setSubject(
-                                ObjectReference.newBuilder().setId("TestSubjectId")
+                                SubjectReference.newBuilder().setSubject(
+                                                ObjectReference.newBuilder().setId("TestSubjectId")
+                                                        .build())
                                         .build())
-                                .build())
                         .build());
                 responseObserver.onCompleted();
             }

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
@@ -1,5 +1,9 @@
 package org.project_kessel.relations.client;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.any;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -7,7 +11,6 @@ import org.project_kessel.clients.authn.AuthenticationConfig;
 
 import java.util.Optional;
 
-import static org.mockito.Mockito.*;
 
 class CDIManagedRelationsClientsTest {
     @Test
@@ -146,7 +149,7 @@ class CDIManagedRelationsClientsTest {
 
             @Override
             public Optional<Config.OIDCClientCredentialsConfig> clientCredentialsConfig() {
-                if(!authnEnabled) {
+                if (!authnEnabled) {
                     return Optional.empty();
                 }
 

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
@@ -1,122 +1,17 @@
 package org.project_kessel.relations.client;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.project_kessel.clients.authn.AuthenticationConfig;
 
-import java.util.Optional;
-
 
 class CDIManagedRelationsClientsTest {
-    @Test
-    void testInsecureNoAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(false));
-        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
-
-        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(RelationsGrpcClientsManager.class)) {
-            cdiManagedRelationsClients.getManager(config);
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
-                    times(1)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
-                    times(0)
-            );
-        }
-    }
-
-    @Test
-    void testInsecureWithAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(true));
-        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
-
-        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(RelationsGrpcClientsManager.class)) {
-            cdiManagedRelationsClients.getManager(config);
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
-                    times(1)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
-                    times(0)
-            );
-        }
-    }
-
-    @Test
-    void testSecureNoAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(false));
-        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
-
-        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(RelationsGrpcClientsManager.class)) {
-            cdiManagedRelationsClients.getManager(config);
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
-                    times(1)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
-                    times(0)
-            );
-        }
-    }
-
-    @Test
-    void testSecureWithAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(true));
-        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
-
-        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(RelationsGrpcClientsManager.class)) {
-            cdiManagedRelationsClients.getManager(config);
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
-                    times(0)
-            );
-            dummyManager.verify(
-                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
-                    times(1)
-            );
-        }
-    }
-
     static Config makeDummyConfig(boolean secure, Config.AuthenticationConfig authnConfig) {
         return new Config() {
             @Override
@@ -140,7 +35,7 @@ class CDIManagedRelationsClientsTest {
         return new Config.AuthenticationConfig() {
             @Override
             public AuthenticationConfig.AuthMode mode() {
-                if(!authnEnabled) {
+                if (!authnEnabled) {
                     return AuthenticationConfig.AuthMode.DISABLED;
                 }
                 // pick some arbitrary non disabled mode
@@ -182,5 +77,113 @@ class CDIManagedRelationsClientsTest {
                 });
             }
         };
+    }
+
+    @Test
+    void testInsecureNoAuthnMakesCorrectManagerCall() {
+        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(false));
+        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
+
+        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
+                RelationsGrpcClientsManager.class)) {
+            cdiManagedRelationsClients.getManager(config);
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
+                    times(1)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
+                    times(0)
+            );
+        }
+    }
+
+    @Test
+    void testInsecureWithAuthnMakesCorrectManagerCall() {
+        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(true));
+        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
+
+        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
+                RelationsGrpcClientsManager.class)) {
+            cdiManagedRelationsClients.getManager(config);
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
+                    times(1)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
+                    times(0)
+            );
+        }
+    }
+
+    @Test
+    void testSecureNoAuthnMakesCorrectManagerCall() {
+        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(false));
+        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
+
+        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
+                RelationsGrpcClientsManager.class)) {
+            cdiManagedRelationsClients.getManager(config);
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
+                    times(1)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
+                    times(0)
+            );
+        }
+    }
+
+    @Test
+    void testSecureWithAuthnMakesCorrectManagerCall() {
+        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(true));
+        CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
+
+        try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
+                RelationsGrpcClientsManager.class)) {
+            cdiManagedRelationsClients.getManager(config);
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forInsecureClients(anyString(), any()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString()),
+                    times(0)
+            );
+            dummyManager.verify(
+                    () -> RelationsGrpcClientsManager.forSecureClients(anyString(), any()),
+                    times(1)
+            );
+        }
     }
 }

--- a/src/test/java/org/project_kessel/relations/client/ConfigTest.java
+++ b/src/test/java/org/project_kessel/relations/client/ConfigTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
-import org.junit.jupiter.api.Test;
 import java.util.HashMap;
+import org.junit.jupiter.api.Test;
 
 
 class ConfigTest {

--- a/src/test/java/org/project_kessel/relations/client/ConfigTest.java
+++ b/src/test/java/org/project_kessel/relations/client/ConfigTest.java
@@ -1,13 +1,12 @@
 package org.project_kessel.relations.client;
 
-import io.smallrye.config.SmallRyeConfigBuilder;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import io.smallrye.config.SmallRyeConfigBuilder;
 import io.smallrye.config.common.MapBackedConfigSource;
 import org.junit.jupiter.api.Test;
-
 import java.util.HashMap;
 
-import static org.junit.jupiter.api.Assertions.fail;
 
 class ConfigTest {
 
@@ -18,19 +17,18 @@ class ConfigTest {
         try {
             new SmallRyeConfigBuilder()
                     .withSources(new MapBackedConfigSource("test", new HashMap<>(), Integer.MAX_VALUE) {
-                                     @Override
-                                     public String getValue(String propertyName) {
-                                         if ("relations-api.target-url".equals(propertyName)) {
-                                             return "http://localhost:8080";
-                                         }
-                                         return null;
-                                     }
-                                 }
+                                @Override
+                                public String getValue(String propertyName) {
+                                    if ("relations-api.target-url".equals(propertyName)) {
+                                        return "http://localhost:8080";
+                                    }
+                                    return null;
+                                }
+                            }
                     )
                     .withMapping(Config.class)
                     .build();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             fail("Generating a config objective with minimal config should not fail.");
         }
     }

--- a/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
@@ -1,42 +1,19 @@
 package org.project_kessel.relations.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
 import org.project_kessel.api.relations.v1beta1.KesselCheckServiceGrpc;
 import org.project_kessel.api.relations.v1beta1.KesselLookupServiceGrpc;
 import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
-import org.junit.jupiter.api.Test;
 import org.project_kessel.clients.KesselClient;
 import org.project_kessel.clients.authn.AuthenticationConfig;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class RelationsGrpcClientsManagerTest {
     /*
      Tests relying on reflection. Brittle and could be removed in future.
      */
-
-    @Test
-    void testSameChannelUsedByClientsInternal() throws Exception {
-        var manager = RelationsGrpcClientsManager.forInsecureClients("localhost:8080");
-        var checkClient = manager.getCheckClient();
-        var relationTuplesClient = manager.getRelationTuplesClient();
-        var lookupClient = manager.getLookupClient();
-
-        var checkAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
-        checkAsyncStubField.setAccessible(true);
-        var checkChannel = ((KesselCheckServiceGrpc.KesselCheckServiceStub)checkAsyncStubField.get(checkClient)).getChannel();
-        var relationTuplesAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
-        relationTuplesAsyncStubField.setAccessible(true);
-        var relationTuplesChannel = ((KesselTupleServiceGrpc.KesselTupleServiceStub)relationTuplesAsyncStubField.get(relationTuplesClient)).getChannel();
-        var lookupAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
-        lookupAsyncStubField.setAccessible(true);
-        var lookupChannel = ((KesselLookupServiceGrpc.KesselLookupServiceStub) lookupAsyncStubField
-                .get(lookupClient)).getChannel();
-
-        assertEquals(checkChannel, relationTuplesChannel);
-        assertEquals(lookupChannel, relationTuplesChannel);
-    }
 
     public static Config.AuthenticationConfig dummyAuthConfigWithGoodOIDCClientCredentials() {
         return new Config.AuthenticationConfig() {
@@ -75,5 +52,29 @@ public class RelationsGrpcClientsManagerTest {
                 });
             }
         };
+    }
+
+    @Test
+    void testSameChannelUsedByClientsInternal() throws Exception {
+        var manager = RelationsGrpcClientsManager.forInsecureClients("localhost:8080");
+        var checkClient = manager.getCheckClient();
+        var relationTuplesClient = manager.getRelationTuplesClient();
+        var lookupClient = manager.getLookupClient();
+
+        var checkAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
+        checkAsyncStubField.setAccessible(true);
+        var checkChannel =
+                ((KesselCheckServiceGrpc.KesselCheckServiceStub) checkAsyncStubField.get(checkClient)).getChannel();
+        var relationTuplesAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
+        relationTuplesAsyncStubField.setAccessible(true);
+        var relationTuplesChannel = ((KesselTupleServiceGrpc.KesselTupleServiceStub) relationTuplesAsyncStubField.get(
+                relationTuplesClient)).getChannel();
+        var lookupAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
+        lookupAsyncStubField.setAccessible(true);
+        var lookupChannel = ((KesselLookupServiceGrpc.KesselLookupServiceStub) lookupAsyncStubField
+                .get(lookupClient)).getChannel();
+
+        assertEquals(checkChannel, relationTuplesChannel);
+        assertEquals(lookupChannel, relationTuplesChannel);
     }
 }

--- a/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
@@ -31,7 +31,8 @@ public class RelationsGrpcClientsManagerTest {
         var relationTuplesChannel = ((KesselTupleServiceGrpc.KesselTupleServiceStub)relationTuplesAsyncStubField.get(relationTuplesClient)).getChannel();
         var lookupAsyncStubField = KesselClient.class.getDeclaredField("asyncStub");
         lookupAsyncStubField.setAccessible(true);
-        var lookupChannel = ((KesselLookupServiceGrpc.KesselLookupServiceStub)lookupAsyncStubField.get(lookupClient)).getChannel();
+        var lookupChannel = ((KesselLookupServiceGrpc.KesselLookupServiceStub) lookupAsyncStubField
+                .get(lookupClient)).getChannel();
 
         assertEquals(checkChannel, relationTuplesChannel);
         assertEquals(lookupChannel, relationTuplesChannel);


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/RHCLOUD-33050

Currently runs validate, build, test.
Linting is taking place before building and will fail the build if a lint violation occurs.

All lint configuration options can be found in google_checks.xml
Majority of changes consisted of whitespace spacing issues, removing .* imports, and line limit lengths (120chars)

FILES LINTED: 
- src/main
- src/test

There is a vscode extension where you can right-click on the `google_checks.xml` file to set configuration to help you resolve issues while you code: https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle
(does not auto-format)

Should be able to do the same with setting Intellij and eclipse's formatters to the `google_checks.xml` file
Info on setting up the checkstyle formatting for intellij: https://stackoverflow.com/a/35273850