### PR TITLE
RHCLOUD-33054 - Pipeline to sync protos

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -1,0 +1,25 @@
+name: sync-protos
+
+on:
+  schedule:
+    - cron: '0 */1 * * *' # every hour.
+
+
+jobs:
+  build:
+    name: Sync protos to clients
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clone relations-api repo
+        run: git clone https://github.com/project-kessel/relations-api.git
+      - name: Copy proto files
+        run: |
+          cp -r relations-api/api/kessel/relations/v1/*.proto src/main/proto/kessel/relations/v1/
+          cp -r relations-api/api/kessel/relations/v1beta1/*.proto src/main/proto/kessel/relations/v1beta1/
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Sync updated proto files'
+          title: Update protos

--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -1,8 +1,9 @@
 name: sync-protos
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '0 */1 * * *' # every hour.
+    - cron: '0 */6 * * *' # every 6 hours.
 
 
 jobs:
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Clone relations-api repo
-        run: git clone https://github.com/project-kessel/relations-api.git
+        run: git clone --depth=1 https://github.com/project-kessel/relations-api.git
       - name: Copy proto files
         run: |
           cp -r relations-api/api/kessel/relations/v1/*.proto src/main/proto/kessel/relations/v1/


### PR DESCRIPTION
@merlante suggestion about moving where the pipeline for syncing proto files simplifies things quite a bit.

Addressing comments from https://github.com/project-kessel/relations-api/pull/143#pullrequestreview-2265582347:
1. Using the peter-evans/create-pull-request action helps simplify a lot of the pull request business. "The default behaviour of the action is to create a pull request that will be continually updated with new changes until it is merged or closed" - https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour
2. Pipeline here runs a cronjob every 6 hours that pulls the relations-api copies any changes over and creates a PR, no PR is opened if no changes are made.
3. Similar action could be added to go & python clients. Should be relatively simple to copy, just requires updating paths.
4. Shouldn't be a problem since the protos will have been already committed to the main branch in the source of truth repo `relations-api`

Currently scheduled to run every 6 hours, but can also be manually triggered so if you want to copy right away you can.
Example PR: https://github.com/lennysgarage/relations-client-java/pull/6

Can also mostly resolve: https://github.com/project-kessel/relations-client-java/pull/14

JIRA: https://issues.redhat.com/browse/RHCLOUD-33054