### PR TITLE
Explicitly add pull-requests: write permission for GH workflow

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Sync protos to clients
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Clone relations-api repo


### PR DESCRIPTION
This is in an effort to avoid having to open permissions at the org level for allowing the action to create a PR.