### PR TITLE
Remove relations-api directory before committing

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           cp -r relations-api/api/kessel/relations/v1/*.proto src/main/proto/kessel/relations/v1/
           cp -r relations-api/api/kessel/relations/v1beta1/*.proto src/main/proto/kessel/relations/v1beta1/
+          rm -rf relations-api/
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
Noticed that the relations-api directory was being committed during the sync protos pull requests. Removed from https://github.com/project-kessel/relations-client-java/pull/27