### PR TITLE
Small refactoring and api changes to improve clarity

### DIFF
--- a/src/main/java/org/project_kessel/relations/client/AuthnConfigConverter.java
+++ b/src/main/java/org/project_kessel/relations/client/AuthnConfigConverter.java
@@ -6,13 +6,13 @@ import org.project_kessel.clients.authn.oidc.client.OIDCClientCredentialsAuthent
 
 public class AuthnConfigConverter {
 
-    public static AuthenticationConfig convert(Config.AuthenticationConfig authnConfig) {
+    public static AuthenticationConfig convert(RelationsConfig.AuthenticationConfig authnConfig) {
         if (authnConfig == null) {
             return null;
         }
         AuthenticationConfig convertedAuthnConfig;
         if (authnConfig.clientCredentialsConfig().isPresent()) {
-            Config.OIDCClientCredentialsConfig oidcClientCredentialsConfig =
+            RelationsConfig.OIDCClientCredentialsConfig oidcClientCredentialsConfig =
                     authnConfig.clientCredentialsConfig().get();
 
             convertedAuthnConfig = new OIDCClientCredentialsAuthenticationConfig();

--- a/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
@@ -13,35 +13,25 @@ import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
 @ApplicationScoped
 public class CDIManagedRelationsClients {
     @Produces
-    RelationsGrpcClientsManager getManager(Config config) {
-        var isSecureClients = config.isSecureClients();
-        var targetUrl = config.targetUrl();
-        var authnEnabled = config.authenticationConfig().map(t -> !t.mode().equals(AuthMode.DISABLED)).orElse(false);
-
-        if (isSecureClients) {
-            if (authnEnabled) {
-                return RelationsGrpcClientsManager.forSecureClients(targetUrl, config.authenticationConfig().get());
-            }
-            return RelationsGrpcClientsManager.forSecureClients(targetUrl);
-        }
-
-        if (authnEnabled) {
-            return RelationsGrpcClientsManager.forInsecureClients(targetUrl, config.authenticationConfig().get());
-        }
-        return RelationsGrpcClientsManager.forInsecureClients(targetUrl);
+    @ApplicationScoped
+    RelationsGrpcClientsManager getManager(RelationsConfig config) {
+        return RelationsGrpcClientsManager.forClientsWithConfig(config);
     }
 
     @Produces
+    @ApplicationScoped
     CheckClient getCheckClient(RelationsGrpcClientsManager manager) {
         return manager.getCheckClient();
     }
 
     @Produces
+    @ApplicationScoped
     RelationTuplesClient getRelationsClient(RelationsGrpcClientsManager manager) {
         return manager.getRelationTuplesClient();
     }
 
     @Produces
+    @ApplicationScoped
     LookupClient getLookupClient(RelationsGrpcClientsManager manager) {
         return manager.getLookupClient();
     }

--- a/src/main/java/org/project_kessel/relations/client/RelationsConfig.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationsConfig.java
@@ -13,7 +13,7 @@ import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
  * Works directly for Quarkus. Might need an implementation class for future Spring Boot config.
  */
 @ConfigMapping(prefix = "relations-api")
-public interface Config {
+public interface RelationsConfig {
     @WithDefault("false")
     boolean isSecureClients();
 

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsContainerTests.java
@@ -41,7 +41,7 @@ class CDIManagedRelationsClientsContainerTests {
     private static Server grpcServer;
     @WeldSetup
     public WeldInitiator weld = WeldInitiator.from(new Weld().setBeanDiscoveryMode(BeanDiscoveryMode.ALL)
-            .addBeanClass(TestConfig.class)).build();
+            .addBeanClass(TestRelationsConfig.class)).build();
     @Inject
     CheckClient checkClient;
     @Inject
@@ -115,9 +115,9 @@ class CDIManagedRelationsClientsContainerTests {
     }
 
     /*
-     Implementation of Config to inject manually with hardcoded settings.
+     Implementation of RelationsConfig to inject manually with hardcoded settings.
      */
-    static class TestConfig implements Config {
+    static class TestRelationsConfig implements RelationsConfig {
         @Override
         public boolean isSecureClients() {
             return false;

--- a/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
+++ b/src/test/java/org/project_kessel/relations/client/CDIManagedRelationsClientsTest.java
@@ -8,12 +8,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.project_kessel.clients.authn.AuthenticationConfig;
 
 
 class CDIManagedRelationsClientsTest {
-    static Config makeDummyConfig(boolean secure, Config.AuthenticationConfig authnConfig) {
-        return new Config() {
+    static RelationsConfig makeDummyConfig(boolean secure, RelationsConfig.AuthenticationConfig authnConfig) {
+        return new RelationsConfig() {
             @Override
             public boolean isSecureClients() {
                 return secure;
@@ -31,8 +32,8 @@ class CDIManagedRelationsClientsTest {
         };
     }
 
-    static Config.AuthenticationConfig makeDummyAuthenticationConfig(boolean authnEnabled) {
-        return new Config.AuthenticationConfig() {
+    static RelationsConfig.AuthenticationConfig makeDummyAuthenticationConfig(boolean authnEnabled) {
+        return new RelationsConfig.AuthenticationConfig() {
             @Override
             public AuthenticationConfig.AuthMode mode() {
                 if (!authnEnabled) {
@@ -43,13 +44,13 @@ class CDIManagedRelationsClientsTest {
             }
 
             @Override
-            public Optional<Config.OIDCClientCredentialsConfig> clientCredentialsConfig() {
+            public Optional<RelationsConfig.OIDCClientCredentialsConfig> clientCredentialsConfig() {
                 if (!authnEnabled) {
                     return Optional.empty();
                 }
 
                 // provide dummy config matching mode, above.
-                return Optional.of(new Config.OIDCClientCredentialsConfig() {
+                return Optional.of(new RelationsConfig.OIDCClientCredentialsConfig() {
                     @Override
                     public String issuer() {
                         return "";
@@ -81,12 +82,13 @@ class CDIManagedRelationsClientsTest {
 
     @Test
     void testInsecureNoAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(false));
+        RelationsConfig config = makeDummyConfig(false, makeDummyAuthenticationConfig(false));
         CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
 
         try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
-                RelationsGrpcClientsManager.class)) {
+                RelationsGrpcClientsManager.class, new CallsRealMethods())) {
             cdiManagedRelationsClients.getManager(config);
+
             dummyManager.verify(
                     () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
                     times(1)
@@ -108,11 +110,11 @@ class CDIManagedRelationsClientsTest {
 
     @Test
     void testInsecureWithAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(false, makeDummyAuthenticationConfig(true));
+        RelationsConfig config = makeDummyConfig(false, makeDummyAuthenticationConfig(true));
         CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
 
         try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
-                RelationsGrpcClientsManager.class)) {
+                RelationsGrpcClientsManager.class, new CallsRealMethods())) {
             cdiManagedRelationsClients.getManager(config);
             dummyManager.verify(
                     () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
@@ -135,11 +137,11 @@ class CDIManagedRelationsClientsTest {
 
     @Test
     void testSecureNoAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(false));
+        RelationsConfig config = makeDummyConfig(true, makeDummyAuthenticationConfig(false));
         CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
 
         try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
-                RelationsGrpcClientsManager.class)) {
+                RelationsGrpcClientsManager.class, new CallsRealMethods())) {
             cdiManagedRelationsClients.getManager(config);
             dummyManager.verify(
                     () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),
@@ -162,11 +164,11 @@ class CDIManagedRelationsClientsTest {
 
     @Test
     void testSecureWithAuthnMakesCorrectManagerCall() {
-        Config config = makeDummyConfig(true, makeDummyAuthenticationConfig(true));
+        RelationsConfig config = makeDummyConfig(true, makeDummyAuthenticationConfig(true));
         CDIManagedRelationsClients cdiManagedRelationsClients = new CDIManagedRelationsClients();
 
         try (MockedStatic<RelationsGrpcClientsManager> dummyManager = Mockito.mockStatic(
-                RelationsGrpcClientsManager.class)) {
+                RelationsGrpcClientsManager.class, new CallsRealMethods())) {
             cdiManagedRelationsClients.getManager(config);
             dummyManager.verify(
                     () -> RelationsGrpcClientsManager.forInsecureClients(anyString()),

--- a/src/test/java/org/project_kessel/relations/client/RelationsConfigTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsConfigTest.java
@@ -8,12 +8,13 @@ import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 
-class ConfigTest {
+class RelationsConfigTest {
 
     @Test
     void canLoadBasicConfig() {
-        /* Should always be able to build a Config from a ConfigSource with just a target url (i.e. minimal config for
-         * now). Also tests whether the mapping annotations in Config are valid beyond static type checking. */
+        /* Should always be able to build a RelationsConfig from a ConfigSource with just a target url (i.e. minimal
+         * config for now). Also tests whether the mapping annotations in RelationsConfig are valid beyond static type
+         * checking. */
         try {
             new SmallRyeConfigBuilder()
                     .withSources(new MapBackedConfigSource("test", new HashMap<>(), Integer.MAX_VALUE) {
@@ -26,7 +27,7 @@ class ConfigTest {
                                 }
                             }
                     )
-                    .withMapping(Config.class)
+                    .withMapping(RelationsConfig.class)
                     .build();
         } catch (Exception e) {
             fail("Generating a config objective with minimal config should not fail.");

--- a/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsGrpcClientsManagerTest.java
@@ -15,16 +15,16 @@ public class RelationsGrpcClientsManagerTest {
      Tests relying on reflection. Brittle and could be removed in future.
      */
 
-    public static Config.AuthenticationConfig dummyAuthConfigWithGoodOIDCClientCredentials() {
-        return new Config.AuthenticationConfig() {
+    public static RelationsConfig.AuthenticationConfig dummyAuthConfigWithGoodOIDCClientCredentials() {
+        return new RelationsConfig.AuthenticationConfig() {
             @Override
             public AuthenticationConfig.AuthMode mode() {
                 return AuthenticationConfig.AuthMode.OIDC_CLIENT_CREDENTIALS; // any non-disabled value
             }
 
             @Override
-            public Optional<Config.OIDCClientCredentialsConfig> clientCredentialsConfig() {
-                return Optional.of(new Config.OIDCClientCredentialsConfig() {
+            public Optional<RelationsConfig.OIDCClientCredentialsConfig> clientCredentialsConfig() {
+                return Optional.of(new RelationsConfig.OIDCClientCredentialsConfig() {
                     @Override
                     public String issuer() {
                         return "http://localhost:8090";


### PR DESCRIPTION
### Changes

1. Renamed `Config` to `RelationsConfig` to make it clearer in client code what it is.
2. Moved logic to create `RelationsGrpcClientsManager` from `RelationsConfig` from `CDIManagedRelationsClients` to `RelationsGrpcClientsManager`, where it can be invoked programmatically as well as by container.
3. Make produced beans `@ApplicationScoped`, which is more useful for notifications and makes quarkus testing more straightforward. (`RelationsGrpcClientsManagers` are effectively application scoped anyhow.)

Only 1. is a breaking change, which I wanted to make sooner rather than later.