### PR TITLE
RHCLOUD-35414 Relations client broken with quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>build.buf</groupId>
       <artifactId>protovalidate</artifactId>
-      <version>0.3.2</version>
+      <version>0.2.1</version>
     </dependency>
     <!-- Default OIDC implementation. Must be provided by the user. -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.project-kessel</groupId>
       <artifactId>common-client-java</artifactId>
-      <version>0.1</version>
+      <version>0.2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.enterprise</groupId>

--- a/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
@@ -13,25 +13,21 @@ import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
 @ApplicationScoped
 public class CDIManagedRelationsClients {
     @Produces
-    @ApplicationScoped
     RelationsGrpcClientsManager getManager(RelationsConfig config) {
         return RelationsGrpcClientsManager.forClientsWithConfig(config);
     }
 
     @Produces
-    @ApplicationScoped
     CheckClient getCheckClient(RelationsGrpcClientsManager manager) {
         return manager.getCheckClient();
     }
 
     @Produces
-    @ApplicationScoped
     RelationTuplesClient getRelationsClient(RelationsGrpcClientsManager manager) {
         return manager.getRelationTuplesClient();
     }
 
     @Produces
-    @ApplicationScoped
     LookupClient getLookupClient(RelationsGrpcClientsManager manager) {
         return manager.getLookupClient();
     }

--- a/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
+++ b/src/main/java/org/project_kessel/relations/client/CDIManagedRelationsClients.java
@@ -13,21 +13,25 @@ import org.project_kessel.clients.authn.AuthenticationConfig.AuthMode;
 @ApplicationScoped
 public class CDIManagedRelationsClients {
     @Produces
+    @ApplicationScoped
     RelationsGrpcClientsManager getManager(RelationsConfig config) {
         return RelationsGrpcClientsManager.forClientsWithConfig(config);
     }
 
     @Produces
+    @ApplicationScoped
     CheckClient getCheckClient(RelationsGrpcClientsManager manager) {
         return manager.getCheckClient();
     }
 
     @Produces
+    @ApplicationScoped
     RelationTuplesClient getRelationsClient(RelationsGrpcClientsManager manager) {
         return manager.getRelationTuplesClient();
     }
 
     @Produces
+    @ApplicationScoped
     LookupClient getLookupClient(RelationsGrpcClientsManager manager) {
         return manager.getLookupClient();
     }


### PR DESCRIPTION
Fixes for the client when used with Quarkus:

1. Bump `common-client-java` to support `@ApplicationScoped` beans (for the cases where synthetic no-arg constructors can only be created when the abstract superclass has a no-args constructor).
2. Downgrade `protovalidate` to a version that supports the version of protoc that is compatible with the code generation plugin.