### PR TITLE
RHCLOUD-35867: Smallrye mutiny reactive importBulkTuplesUni call to simplify bulk imports

### DIFF
--- a/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
@@ -6,8 +6,15 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import java.util.Iterator;
-
-import org.project_kessel.api.relations.v1beta1.*;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.DeleteTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.DeleteTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
 import org.project_kessel.clients.KesselClient;
 
 public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.KesselTupleServiceStub,

--- a/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
@@ -3,17 +3,14 @@ package org.project_kessel.relations.client;
 import io.grpc.Channel;
 import io.grpc.stub.StreamObserver;
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import java.util.Iterator;
-import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.DeleteTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.DeleteTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesResponse;
-import org.project_kessel.api.relations.v1beta1.KesselTupleServiceGrpc;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesRequest;
-import org.project_kessel.api.relations.v1beta1.ReadTuplesResponse;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.project_kessel.api.relations.v1beta1.*;
 import org.project_kessel.clients.KesselClient;
 
 public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.KesselTupleServiceStub,
@@ -103,5 +100,98 @@ public class RelationTuplesClient extends KesselClient<KesselTupleServiceGrpc.Ke
     public StreamObserver<ImportBulkTuplesRequest> importBulkTuples(
             StreamObserver<ImportBulkTuplesResponse> responseObserver) {
         return asyncStub.importBulkTuples(responseObserver);
+    }
+
+    /*
+     * Looks ok if I feel like I get nothing from async.
+     */
+    public ImportBulkTuplesResponse importBulkTuples(ImportBulkTuplesRequest bulkTuplesRequest) {
+        return importBulkTuplesUni(Uni.createFrom().item(bulkTuplesRequest)).await().indefinitely(); // TODO: add timeout
+    }
+
+    /*
+     * Looks good
+     */
+    public Uni<ImportBulkTuplesResponse> importBulkTuples2(ImportBulkTuplesRequest bulkTuplesRequest) {
+        return importBulkTuplesUni(Uni.createFrom().item(bulkTuplesRequest));
+    }
+
+    /*
+     * Not sure the multi gives us much, see importBulkTuplesUni(Multi<Relationship> relationshipsStream), below
+     */
+    public ImportBulkTuplesResponse importBulkTuples3(Multi<Relationship> relationshipsStream) {
+        Uni<ImportBulkTuplesResponse> responseUni = importBulkTuplesUni(relationshipsStream);
+
+        return responseUni.await().indefinitely();
+    }
+
+    /*
+     * Looks ok.
+     */
+    public Uni<ImportBulkTuplesResponse> importBulkTuplesUni(Uni<ImportBulkTuplesRequest> bulkTuplesRequest) {
+        final UnicastProcessor<ImportBulkTuplesResponse> responseProcessor = UnicastProcessor.create();
+
+        var responseObserver = new StreamObserver<ImportBulkTuplesResponse>() {
+            @Override
+            public void onNext(ImportBulkTuplesResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+
+        StreamObserver<ImportBulkTuplesRequest> requestObserver = importBulkTuples(responseObserver);
+        bulkTuplesRequest.onItem()
+                .invoke(requestObserver::onNext)
+                .invoke(requestObserver::onCompleted) // we're expecting just one request
+                .onFailure().invoke(responseObserver::onError)
+                .await().indefinitely(); // TODO: think about timeout
+
+        return Uni.createFrom().publisher(responseProcessor);
+    }
+
+    /**
+     * I thought we could stream in the relationships, but we are streaming the requests really... so I'm not sure
+     * if we get much
+     */
+    public Uni<ImportBulkTuplesResponse> importBulkTuplesUni(Multi<Relationship> relationshipsStream) {
+        final UnicastProcessor<ImportBulkTuplesResponse> responseProcessor = UnicastProcessor.create();
+
+        var responseObserver = new StreamObserver<ImportBulkTuplesResponse>() {
+            @Override
+            public void onNext(ImportBulkTuplesResponse response) {
+                responseProcessor.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                responseProcessor.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                responseProcessor.onComplete();
+            }
+        };
+
+        StreamObserver<ImportBulkTuplesRequest> requestObserver = importBulkTuples(responseObserver);
+        ImportBulkTuplesRequest importBulkTuplesRequest = ImportBulkTuplesRequest.newBuilder()
+                // I thought we could somehow stream relationships here, but we have to provide a list
+                // since we have to block here to build the list, what do we really get from multi?
+                // maybe we avoid having to traverse the list twice...
+                .addAllTuples(relationshipsStream.collect().asList().await().indefinitely())
+                .build();
+        requestObserver.onNext(importBulkTuplesRequest);
+        requestObserver.onCompleted();
+
+        return Uni.createFrom().publisher(responseProcessor);
     }
 }

--- a/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
+++ b/src/main/java/org/project_kessel/relations/client/RelationTuplesClient.java
@@ -6,9 +6,6 @@ import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.operators.multi.processors.UnicastProcessor;
 import java.util.Iterator;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.project_kessel.api.relations.v1beta1.*;
 import org.project_kessel.clients.KesselClient;

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -141,7 +141,6 @@ class RelationTuplesClientServerTest {
             public void subscribe(Flow.Subscriber<? super ImportBulkTuplesRequest> subscriber) {
                 if (times++ == 0) {
                     subscriber.onNext(req1);
-                    subscriber.onComplete();
                 } else {
                     // mimics an exception thrown by any method attempting to construct a ImportBulkTuplesRequest to
                     // supply onNext()

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -1,0 +1,123 @@
+package org.project_kessel.relations.client;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.project_kessel.api.relations.v1beta1.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RelationTuplesClientServerTest {
+    static final int SERVER_PORT = 9000;
+
+    static RelationTuplesClient client;
+
+    @BeforeAll
+    static void setupAll() {
+        var manager = RelationsGrpcClientsManager.forInsecureClients("0.0.0.0:" + SERVER_PORT);
+        client = manager.getRelationTuplesClient();
+    }
+
+    @BeforeEach
+    void setUp() {
+        deleteRelationships();
+    }
+
+    @Test
+    void testImportBulkTuplesUni() {
+        List<Relationship> batch1 = relationshipListMaker(0, 10);
+        List<Relationship> batch2 = relationshipListMaker(15, 20);
+        ImportBulkTuplesRequest req1 = ImportBulkTuplesRequest.newBuilder().addAllTuples(batch1).build();
+        ImportBulkTuplesRequest req2 = ImportBulkTuplesRequest.newBuilder().addAllTuples(batch2).build();
+        Multi<ImportBulkTuplesRequest> bulkTuplesRequests = Multi.createFrom().items(req1, req2);
+        Uni<ImportBulkTuplesResponse> importBulkTuplesResponseUni = client.importBulkTuplesUni(bulkTuplesRequests);
+
+        var failure = new AtomicReference<Throwable>();
+        var response = importBulkTuplesResponseUni
+                .onFailure().invoke(failure::set)
+                .onFailure().recoverWithNull()
+                .await().indefinitely();
+
+        assertEquals(15, response.getNumImported());
+    }
+
+    @Test
+    void testErrorDoesNotCallOnComplete() {
+        List<Relationship> batch1 = relationshipListMaker(0, 10);
+        List<Relationship> batch2 = relationshipListMaker(9, 10); // repeat rel from batch 1 -- induce batch2 processing failure
+        List<Relationship> batch3 = relationshipListMaker(15, 20);
+        ImportBulkTuplesRequest req1 = ImportBulkTuplesRequest.newBuilder().addAllTuples(batch1).build();
+        ImportBulkTuplesRequest req2 = ImportBulkTuplesRequest.newBuilder().addAllTuples(batch2).build();
+        ImportBulkTuplesRequest req3 = ImportBulkTuplesRequest.newBuilder().addAllTuples(batch3).build();
+        Multi<ImportBulkTuplesRequest> bulkTuplesRequests = Multi.createFrom().items(req1, req2, req3);
+        Uni<ImportBulkTuplesResponse> importBulkTuplesResponseUni = client.importBulkTuplesUni(bulkTuplesRequests);
+
+        var failure = new AtomicReference<Throwable>();
+
+        /*
+         * debugger verifies that responseObserver onComplete() in error scenarios
+         */
+
+        // First option -- catch Exception
+//        ImportBulkTuplesResponse response = null;
+//        try {
+//            response = importBulkTuplesResponseUni.await().indefinitely();
+//        } catch (Throwable t) {
+//            failure.set(t);
+//            // - debugger verifies that onComplete() in not called
+//        }
+
+        // Second option -- store and suppress exception and complete Uni (not responseObserver which does not complete)
+        var response = importBulkTuplesResponseUni
+                .onFailure().invoke(failure::set)
+                .onFailure().recoverWithNull()
+                .await().indefinitely();
+
+        assertNull(response);
+        assertEquals(io.grpc.StatusRuntimeException.class, failure.get().getClass());
+        assertTrue(failure.get().getMessage().startsWith("ALREADY_EXISTS: error import bulk tuples: error receiving "
+                + "response from Spicedb for bulkimport request"));
+    }
+
+    List<Relationship> relationshipListMaker(int startPostfix, int endPostfix) {
+        return IntStream.range(startPostfix, endPostfix).mapToObj(i ->
+                relationshipMaker("thing_" + i, "workspace_" + i)
+        ).collect(Collectors.toList());
+    }
+
+    void deleteRelationships() {
+        DeleteTuplesRequest req = DeleteTuplesRequest.newBuilder()
+                .setFilter(RelationTupleFilter.newBuilder()
+                        .setResourceNamespace("rbac")
+                        .setResourceType("thing")
+                        .build())
+                .build();
+        client.deleteTuples(req);
+    }
+
+    Relationship relationshipMaker(String thingId, String workspaceId) {
+        return Relationship.newBuilder()
+                .setSubject(SubjectReference.newBuilder()
+                        .setSubject(ObjectReference.newBuilder()
+                                .setType(ObjectType.newBuilder()
+                                        .setNamespace("rbac")
+                                        .setName("workspace").build())
+                                .setId(workspaceId).build())
+                        .build())
+                .setRelation("workspace")
+                .setResource(ObjectReference.newBuilder()
+                        .setType(ObjectType.newBuilder()
+                                .setNamespace("rbac")
+                                .setName("thing").build())
+                        .setId(thingId)
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -84,6 +84,7 @@ class RelationTuplesClientServerTest {
         assertEquals(io.grpc.StatusRuntimeException.class, failure.get().getClass());
         assertTrue(failure.get().getMessage().startsWith("ALREADY_EXISTS: error import bulk tuples: error receiving "
                 + "response from Spicedb for bulkimport request"));
+        // TODO: add assert to show no relations are written -- verified manually that by looking at spicedb
     }
 
     List<Relationship> relationshipListMaker(int startPostfix, int endPostfix) {

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -62,7 +62,7 @@ class RelationTuplesClientServerTest {
         var failure = new AtomicReference<Throwable>();
 
         /*
-         * debugger verifies that responseObserver onComplete() in error scenarios
+         * debugger verifies that responseObserver onComplete() not called in error scenarios
          */
 
         // First option -- catch Exception

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -2,26 +2,22 @@ package org.project_kessel.relations.client;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.project_kessel.api.relations.v1beta1.*;
 
 import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Disabled("Disabled until a relations-api test container becomes available.")
 class RelationTuplesClientServerTest {
     static final int SERVER_PORT = 9000;
 

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -94,7 +94,6 @@ class RelationTuplesClientServerTest {
         assertEquals(io.grpc.StatusRuntimeException.class, failure.get().getClass());
         assertTrue(failure.get().getMessage().startsWith("ALREADY_EXISTS: error import bulk tuples: error receiving "
                 + "response from Spicedb for bulkimport request"));
-        assertEquals(0L, countStoredRelationsips());
         // Without read after write consistency, we try to wait for relations-api to give an updated read view
 //        try {
 //            Thread.sleep(4000);

--- a/src/test/java/org/project_kessel/relations/client/RelationsConfigTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationsConfigTest.java
@@ -28,7 +28,7 @@ class RelationsConfigTest {
                             }
                     )
                     .withMapping(RelationsConfig.class)
-                    .build();
+                    .build().getConfigMapping(RelationsConfig.class);
         } catch (Exception e) {
             fail("Generating a config objective with minimal config should not fail.");
         }


### PR DESCRIPTION
### What's included

1. New method `public Uni<ImportBulkTuplesResponse> importBulkTuplesUni(Multi<ImportBulkTuplesRequest> bulkTuplesRequests)` added to simplify the interface for bulk import. (Two StreamObservers approach very counterintuitive for users).
2. Tests added to prove functionality and error scenarios in the wiring between the grpc StreamObservers and the mutiny Multi/Uni. (Tests disabled by default in lieu of a relations-api test container.)

### Coming soon

1. An example in the Caller class and new docs.