### PR TITLE
Change examples from user to principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var checkClient = clientsManager.getCheckClient();
 ### Making requests
 #### Synchronous example
 
-Let's say we want to check whether a subject of type "user" (in the "rbac" type namespace) with id "bob" has "view" permission to a resource of type "thing" (in the "rbac" type namespace) and id "my_thing". We can make the following synchronous check request:
+Let's say we want to check whether a subject of type "principal" (in the "rbac" type namespace) with id "bob" has "view" permission to a resource of type "widget" (in the "rbac" type namespace) and id "my_thing". We can make the following synchronous check request:
 
 ```java
 var checkRequest = CheckRequest.newBuilder()
@@ -37,14 +37,14 @@ var checkRequest = CheckRequest.newBuilder()
                 .setSubject(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
                                 .setNamespace("rbac")
-                                .setName("user").build())
+                                .setName("principal").build())
                         .setId("bob").build())
                 .build())
         .setRelation("view")
         .setResource(ObjectReference.newBuilder()
                 .setType(ObjectType.newBuilder()
                         .setNamespace("rbac")
-                        .setName("thing").build())
+                        .setName("widget").build())
                 .setId("my_thing")
                 .build())
         .build();
@@ -55,17 +55,17 @@ var permitted = checkResponse.getAllowed() == CheckResponse.Allowed.ALLOWED_TRUE
 
 #### Asynchronous reactive example (using Mutiny)
 
-Let's say we want to look up all of the resources of type "thing" (in the "rbac" type namespace) that a subject of type "user" (in the "rbac" type namespace) and id "bob" has "view" permission on. Since there may be many responses, we might want to operate on them asynchronously as they come in, but we may also want to collect them all afterwards and perform a synchronous operation on the list. We can make the following request using the mutiny reactive programming API to achieve both:
+Let's say we want to look up all of the resources of type "widget" (in the "rbac" type namespace) that a subject of type "principal" (in the "rbac" type namespace) and id "bob" has "view" permission on. Since there may be many responses, we might want to operate on them asynchronously as they come in, but we may also want to collect them all afterwards and perform a synchronous operation on the list. We can make the following request using the mutiny reactive programming API to achieve both:
 
 ```java
 var lookupResourcesRequest = LookupResourcesRequest.newBuilder()
         .setResourceType(ObjectType.newBuilder()
-                .setNamespace("rbac").setName("thing"))
+                .setNamespace("rbac").setName("widget"))
         .setRelation("view").setSubject(SubjectReference.newBuilder()
                 .setSubject(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
                                 .setNamespace("rbac")
-                                .setName("user").build())
+                                .setName("principal").build())
                         .setId("bob").build())
                 .build()).build();
 

--- a/src/main/java/org/project_kessel/relations/example/Caller.java
+++ b/src/main/java/org/project_kessel/relations/example/Caller.java
@@ -26,10 +26,10 @@ import org.project_kessel.relations.client.RelationsGrpcClientsManager;
 public class Caller {
 
     static final String userName = "joe";
-    static final String subjectType = "user";
+    static final String subjectType = "principal";
     static final String permission = "view";
     static final String namespace = "rbac";
-    static final String resourceType = "thing";
+    static final String resourceType = "widget";
     static final String resourceId = "my_thing";
 
     public static void main(String[] argv) {

--- a/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
+++ b/src/test/java/org/project_kessel/relations/client/RelationTuplesClientServerTest.java
@@ -178,14 +178,14 @@ class RelationTuplesClientServerTest {
 
     List<Relationship> relationshipListMaker(int startPostfix, int endPostfix) {
         return IntStream.range(startPostfix, endPostfix).mapToObj(i ->
-                relationshipMaker("thing_" + i, "workspace_" + i)
+                relationshipMaker("widget_" + i, "workspace_" + i)
         ).collect(Collectors.toList());
     }
 
     @SuppressWarnings("SameParameterValue")
     List<Relationship> badRelationshipListMaker(int startPostfix, int endPostfix) {
         return IntStream.range(startPostfix, endPostfix).mapToObj(i ->
-                badRelationshipMaker("thing_" + i, "workspace_" + i)
+                badRelationshipMaker("widget_" + i, "workspace_" + i)
         ).collect(Collectors.toList());
     }
 
@@ -193,7 +193,7 @@ class RelationTuplesClientServerTest {
         DeleteTuplesRequest req = DeleteTuplesRequest.newBuilder()
                 .setFilter(RelationTupleFilter.newBuilder()
                         .setResourceNamespace("rbac")
-                        .setResourceType("thing")
+                        .setResourceType("widget")
                         .build())
                 .build();
         client.deleteTuples(req);
@@ -212,7 +212,7 @@ class RelationTuplesClientServerTest {
                 .setResource(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
                                 .setNamespace("rbac")
-                                .setName("thing").build())
+                                .setName("widget").build())
                         .setId(thingId)
                         .build())
                 .build();
@@ -231,7 +231,7 @@ class RelationTuplesClientServerTest {
                 .setResource(ObjectReference.newBuilder()
                         .setType(ObjectType.newBuilder()
                                 .setNamespace("rbac")
-                                .setName("thing").build())
+                                .setName("widget").build())
                         .setId(thingId)
                         .build())
                 .build();
@@ -243,7 +243,7 @@ class RelationTuplesClientServerTest {
         ReadTuplesRequest request = ReadTuplesRequest.newBuilder()
                 .setFilter(RelationTupleFilter.newBuilder()
                         .setResourceNamespace("rbac")
-                        .setResourceType("thing")
+                        .setResourceType("widget")
                         .build())
                 .build();
         var relResponses = StreamSupport.stream(


### PR DESCRIPTION
Updates instances of `user` in examples and tests to `principal` inline with updated schema.
Updates instances of `thing` in examples to `widget` inline with updated schema.