### PR TITLE
Update README.md for deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⛔️ This repository is no longer actively maintained. Please consider using [kessel-sdk-java](https://github.com/project-kessel/kessel-sdk-java) instead ⛔️
+
 # relations-client-java
 Java client library for the relations api.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a prominent deprecation notice to the README pointing users to the kessel-sdk-java repository as a replacement.